### PR TITLE
No compilation for minified code

### DIFF
--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -65,6 +65,11 @@ export default class CompileCache {
       return false;
     }
 
+    // If the file is minified, we probably shouldn't compile it either
+    if (sourceCode && CompileCache.isMinified(sourceCode)) {
+      return false;
+    }
+
     // NB: require() normally does this for us, but in our protocol hook we
     // need to do this ourselves
     return _.some(

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -32,6 +32,26 @@ export default class CompileCache {
     throw new Error("Implement this in a derived class");
   }
 
+  static isMinified(source) {
+    let length = source.length;
+    if (length > 2048) length = 2048;
+
+    let newlineCount = 0;
+
+    // Roll through the characters and determine the average line length
+    for(let i=0; i < source.length; i++) {
+      if (source[i] === '\n') newlineCount++;
+    }
+
+    // No Newlines? Any file other than a super small one is minified
+    if (newlineCount === 0) {
+      return (length > 40);
+    }
+
+    let avgLineLength = length / newlineCount;
+    return (avgLineLength > 80);
+  }
+
   shouldCompileFile(fullPath, sourceCode=null) {
     this.ensureInitialized();
     let lowerPath = fullPath.toLowerCase();

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -34,7 +34,7 @@ export default class CompileCache {
 
   static isMinified(source) {
     let length = source.length;
-    if (length > 2048) length = 2048;
+    if (length > 1024) length = 1024;
     
     let newlineCount = 0;
     
@@ -49,7 +49,7 @@ export default class CompileCache {
     }
     
     let avgLineLength = length / newlineCount;
-    return (avgLineLength > 80);
+    return (avgLineLength > 40);
   }
 
   shouldCompileFile(fullPath, sourceCode=null) {

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -35,19 +35,19 @@ export default class CompileCache {
   static isMinified(source) {
     let length = source.length;
     if (length > 2048) length = 2048;
-
+    
     let newlineCount = 0;
-
+    
     // Roll through the characters and determine the average line length
     for(let i=0; i < source.length; i++) {
       if (source[i] === '\n') newlineCount++;
     }
-
+    
     // No Newlines? Any file other than a super small one is minified
     if (newlineCount === 0) {
       return (length > 40);
     }
-
+    
     let avgLineLength = length / newlineCount;
     return (avgLineLength > 80);
   }
@@ -64,7 +64,7 @@ export default class CompileCache {
     if (sourceCode && sourceCode.lastIndexOf('//# sourceMap') > sourceCode.lastIndexOf('\n')) {
       return false;
     }
-
+    
     // If the file is minified, we probably shouldn't compile it either
     if (sourceCode && CompileCache.isMinified(sourceCode)) {
       return false;
@@ -145,7 +145,7 @@ export default class CompileCache {
 
       // NB: Even if all of the directories exist, if you mkdirp in an ASAR archive it throws
       if (!this.jsCacheDir.match(/[\\\/]app\.asar/)) {
-      	mkdirp.sync(this.jsCacheDir);
+        mkdirp.sync(this.jsCacheDir);
       }
     }
 


### PR DESCRIPTION
Ignore minified code when looking for files to compile. We define minified code as code whose line length is on average > 40 chars (which doesn't sound like a lot but it is!) 
