### PR TITLE
Clean up lib folder before recompiling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Base class for compilers in electron-compile, use this to implement your own compiler",
   "main": "lib/compile-cache.js",
   "scripts": {
-    "compile": "babel --stage 0 -d lib/ src/",
+    "compile": "git clean -xdf lib && babel --stage 0 -d lib/ src/",
     "prepublish": "npm run compile"
   },
   "repository": {


### PR DESCRIPTION
This actually surfaced in electron-compilers, but I'm pr-ing the fix into all 3 associated repos. Basically, use git to clean out the lib folder whenever a compile runs (including prepublish) to prevent accidentally publishing compiled files who's source has been removed.
